### PR TITLE
update to 3.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ To manage the continuous integration and simplify feedstock maintenance
 Using the ``conda-forge.yml`` within this repository, it is possible to re-render all of
 this feedstock's supporting files (e.g. the CI configuration files) with ``conda smithy rerender``.
 
+For more information please check the [conda-forge documentation](https://conda-forge.org/docs/).
 
 Terminology
 ===========

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,24 +35,24 @@ install:
 
     # Add path, activate `conda` and update conda.
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
-    - cmd: conda update --yes --quiet conda
+    - cmd: conda.exe update --yes --quiet conda
 
     - cmd: set PYTHONUNBUFFERED=1
 
     # Add our channels.
-    - cmd: conda config --set show_channel_urls true
-    - cmd: conda config --remove channels defaults
-    - cmd: conda config --add channels defaults
-    - cmd: conda config --add channels conda-forge
+    - cmd: conda.exe config --set show_channel_urls true
+    - cmd: conda.exe config --remove channels defaults
+    - cmd: conda.exe config --add channels defaults
+    - cmd: conda.exe config --add channels conda-forge
 
     # Configure the VM.
-    - cmd: conda install -n root --quiet --yes conda-forge-build-setup
+    - cmd: conda.exe install -n root --quiet --yes conda-forge-build-setup
     - cmd: run_conda_forge_build_setup
 
 # Skip .NET project specific build phase.
 build: off
 
 test_script:
-    - conda build recipe --quiet
+    - conda.exe build recipe --quiet
 deploy_script:
     - cmd: upload_or_check_non_existence .\recipe conda-forge --channel=main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.3.2" %}
+{% set version = "3.4.1" %}
 
 package:
   name: r-recommended
@@ -26,6 +26,13 @@ requirements:
     - r-rpart
     - r-spatial
     - r-survival
+
+# test to force the test env creation
+# if any dependency is missing the test env creation will fail
+test:
+  commands:
+    - $R -e "library('MASS')"  # [not win]
+    - "\"%R%\" -e \"library('MASS')\""  # [win]
 
 about:
   home: http://www.r-project.org/


### PR DESCRIPTION

I am also adding a test.

if the recipe doesn't have a test conda skips the test-env creation, by adding one the creation of the test-env will make sure all dependencies exist.