### PR TITLE
fix r-3.6 build

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -10,8 +10,12 @@ jobs:
   strategy:
     maxParallel: 8
     matrix:
-      linux_:
-        CONFIG: linux_
+      linux_r_base3.5.1:
+        CONFIG: linux_r_base3.5.1
+        UPLOAD_PACKAGES: True
+        DOCKER_IMAGE: condaforge/linux-anvil-comp7
+      linux_r_base3.6:
+        CONFIG: linux_r_base3.6
         UPLOAD_PACKAGES: True
         DOCKER_IMAGE: condaforge/linux-anvil-comp7
   steps:

--- a/.ci_support/linux_r_base3.5.1.yaml
+++ b/.ci_support/linux_r_base3.5.1.yaml
@@ -4,3 +4,9 @@ channel_targets:
 - conda-forge main
 docker_image:
 - condaforge/linux-anvil-comp7
+pin_run_as_build:
+  r-base:
+    min_pin: x.x
+    max_pin: x.x
+r_base:
+- 3.5.1

--- a/.ci_support/linux_r_base3.6.yaml
+++ b/.ci_support/linux_r_base3.6.yaml
@@ -1,0 +1,12 @@
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+docker_image:
+- condaforge/linux-anvil-comp7
+pin_run_as_build:
+  r-base:
+    min_pin: x.x
+    max_pin: x.x
+r_base:
+- '3.6'

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @bgruening @cbrueffer @conda-forge/r @daler @dbast @jdblischak @johanneskoester
+* @conda-forge/r

--- a/README.md
+++ b/README.md
@@ -116,11 +116,5 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
-* [@bgruening](https://github.com/bgruening/)
-* [@cbrueffer](https://github.com/cbrueffer/)
 * [@conda-forge/r](https://github.com/conda-forge/r/)
-* [@daler](https://github.com/daler/)
-* [@dbast](https://github.com/dbast/)
-* [@jdblischak](https://github.com/jdblischak/)
-* [@johanneskoester](https://github.com/johanneskoester/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,9 +43,3 @@ about:
 extra:
   recipe-maintainers:
     - conda-forge/r
-    - johanneskoester
-    - bgruening
-    - daler
-    - jdblischak
-    - cbrueffer
-    - dbast

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,8 +1,7 @@
-{% set version = "3.5.1" %}
 
 package:
   name: r-recommended
-  version: {{ version }}
+  version: {{ r_base }}
 
 build:
   noarch: generic
@@ -10,9 +9,9 @@ build:
 
 requirements:
   host:
-      - r-base {{ version }}
+      - r-base {{ r_base }}
   run:
-    - r-base {{ version }}
+    - r-base {{ r_base }}
     - r-boot
     - r-class
     - r-cluster

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,13 +5,13 @@ package:
 
 build:
   noarch: generic
-  number: 1002
+  number: 1003
 
 requirements:
   host:
-      - r-base {{ r_base }}
+      - r-base
   run:
-    - r-base {{ r_base }}
+    - r-base
     - r-boot
     - r-class
     - r-cluster


### PR DESCRIPTION

this package version string must match the r-base package.

also rerender because it didn't pick up the r-3.6 CI files on the other PR for some reason.